### PR TITLE
Separating graph structure from graph computations (David's first pull request ever)

### DIFF
--- a/cnn/cnn.cc
+++ b/cnn/cnn.cc
@@ -7,25 +7,15 @@ using namespace std;
 
 namespace cnn {
 
-int n_hgs = 0;
-
 Edge::~Edge() {}
 
 bool Edge::has_parameters() const { return false; }
 
-Hypergraph::Hypergraph() : last_node_evaluated() {
-  ++n_hgs;
-  if (n_hgs > 1) {
-    // TODO handle memory better
-    cerr << "Memory allocator assumes only a single hypergraph at a time.\n";
-    abort();
-  }
-}
+Hypergraph::Hypergraph() : running(false) { }
 
 Hypergraph::~Hypergraph() {
   for (auto n : nodes) delete n;
   for (auto e : edges) delete e;
-  --n_hgs;
 }
 
 VariableIndex Hypergraph::add_input(real s) {
@@ -105,25 +95,25 @@ VariableIndex Hypergraph::add_const_lookup(LookupParameters* p, unsigned index) 
   return new_node_index;
 }
 
-const Tensor& Hypergraph::incremental_forward() {
+const Tensor& Run::incremental_forward() {
   // free any old memory if this is a new HG
   if (last_node_evaluated == 0) {
     fxs->free();
     dEdfs->zero_and_free();
   }
 
-  assert(nodes.size() > 0);
-  if (nodes.size() - last_node_evaluated == 0) {
-    return nodes.back()->f;
+  assert(hg->nodes.size() > 0);
+  if (hg->nodes.size() - last_node_evaluated == 0) {
+    return hg->nodes.back()->f;
   }
   vector<Dim> xds;
-  for (unsigned i = last_node_evaluated; i < nodes.size(); ++i) {
-    Node* node = nodes[i];
-    const Edge& in_edge = *edges[node->in_edge];
+  for (unsigned i = last_node_evaluated; i < hg->nodes.size(); ++i) {
+    Node* node = hg->nodes[i];
+    const Edge& in_edge = *hg->edges[node->in_edge];
     xds.resize(in_edge.arity());
     unsigned ti = 0;
     for (VariableIndex tail_node_index : in_edge.tail) {
-      xds[ti] = nodes[tail_node_index]->dim;
+      xds[ti] = hg->nodes[tail_node_index]->dim;
       ++ti;
     }
     node->dim = in_edge.dim_forward(xds);
@@ -137,32 +127,32 @@ const Tensor& Hypergraph::incremental_forward() {
 
   //vector<string> dummy(5, "x");
   vector<const Tensor*> xs;
-  while (last_node_evaluated < nodes.size()) {
-    Node* node = nodes[last_node_evaluated];
-    const Edge& in_edge = *edges[node->in_edge];
+  while (last_node_evaluated < hg->nodes.size()) {
+    Node* node = hg->nodes[last_node_evaluated];
+    const Edge& in_edge = *hg->edges[node->in_edge];
     xs.resize(in_edge.arity());
     unsigned ti = 0;
     for (VariableIndex tail_node_index : in_edge.tail) {
-      xs[ti] = &nodes[tail_node_index]->f;
+      xs[ti] = &hg->nodes[tail_node_index]->f;
       ++ti;
     }
     in_edge.forward(xs, node->f);
     ++last_node_evaluated;
   }
-  return nodes.back()->f;
+  return hg->nodes.back()->f;
 }
 
-const Tensor& Hypergraph::forward() {
+const Tensor& Run::forward() {
   last_node_evaluated = 0;
   return incremental_forward();
 }
 
-void Hypergraph::backward() {
+void Run::backward() {
   // here we find constants to avoid doing extra work
-  vector<bool> needs_derivative(nodes.size(), false);
-  for (unsigned ni = 0; ni < nodes.size(); ++ni) {
-    const Node& node = *nodes[ni];
-    const Edge& in_edge = *edges[node.in_edge];
+  vector<bool> needs_derivative(hg->nodes.size(), false);
+  for (unsigned ni = 0; ni < hg->nodes.size(); ++ni) {
+    const Node& node = *hg->nodes[ni];
+    const Edge& in_edge = *hg->edges[node.in_edge];
     bool is_variable = in_edge.has_parameters();
     for (auto tail_node : in_edge.tail)
       is_variable |= needs_derivative[tail_node];
@@ -170,22 +160,22 @@ void Hypergraph::backward() {
   }
 
   // initialize dE/dE = 1
-  nodes.back()->dEdf.v[0] = 1;
+  hg->nodes.back()->dEdf.v[0] = 1;
 
   // loop in reverse topological order
   vector<const Tensor*> xs;
-  for (int i = nodes.size() - 1; i >= 0; --i) {
-    const Node& node = *nodes[i];
-    const Edge& in_edge = *edges[node.in_edge];
+  for (int i = hg->nodes.size() - 1; i >= 0; --i) {
+    const Node& node = *hg->nodes[i];
+    const Edge& in_edge = *hg->edges[node.in_edge];
     unsigned ti = 0;
     xs.resize(in_edge.arity());
     for (unsigned tail_node_index : in_edge.tail) {
-      xs[ti] = &nodes[tail_node_index]->f;
+      xs[ti] = &hg->nodes[tail_node_index]->f;
       ++ti;
     }
     for (unsigned ti = 0; ti < in_edge.tail.size(); ++ti) {
       if (needs_derivative[in_edge.tail[ti]]) {
-        Node& tail_node = *nodes[in_edge.tail[ti]];
+        Node& tail_node = *hg->nodes[in_edge.tail[ti]];
         in_edge.backward(xs, node.f, node.dEdf, ti, tail_node.dEdf);
       }
     }
@@ -199,8 +189,8 @@ void Hypergraph::backward() {
   // this is simpler than you might find in some other frameworks
   // since we assume parameters come into the graph as a "function"
   // that returns the current value of the parameters
-  for (auto pedge : parameter_edges)
-    pedge->accumulate_grad(nodes[pedge->head_node]->dEdf);
+  for (auto pedge : hg->parameter_edges)
+    pedge->accumulate_grad(hg->nodes[pedge->head_node]->dEdf);
 }
 
 void Hypergraph::PrintGraphviz() const {

--- a/cnn/cnn.h
+++ b/cnn/cnn.h
@@ -42,8 +42,6 @@ struct Hypergraph {
   Hypergraph();
   ~Hypergraph();
 
-  bool running; // prevents more than one Run at a time
-
   // INPUTS
   // the computational network will pull inputs in from the user's data
   // structures and make them available to the computation
@@ -77,7 +75,6 @@ struct Hypergraph {
   // data
   std::vector<Node*> nodes;       // **stored in topological order**
   std::vector<Edge*> edges;       // all edges
-  std::vector<void*> memory_pool; // free this
   std::vector<ParameterEdgeBase*> parameter_edges; // edges that contain parameters that can be updated (subset of edges)
 };
 
@@ -97,23 +94,13 @@ struct Node {
   unsigned in_edge;
   std::vector<unsigned> out_edges;
 
-  // memory
-  Dim dim;  // will be .size() = 0 initially, before memory is allocated
-
   // debugging
   std::string variable_name() const { return "v" + std::to_string(node_id); }
   VariableIndex node_id;  // my id
-
-  // computation results (nb. memory is not owned by Tensor)
-  Tensor f;               // f(x_1 , ... , x_n)
-  Tensor dEdf;            // dE/df
 };
 
 inline void swap(Node& n1, Node& n2) {
   using std::swap;
-  swap(n1.dim, n2.dim);
-  swap(n1.f, n2.f);
-  swap(n1.dEdf, n2.dEdf);
   swap(n1.in_edge, n2.in_edge);
   swap(n1.out_edges, n2.out_edges);
   swap(n1.node_id, n2.node_id);
@@ -209,31 +196,46 @@ inline VariableIndex Hypergraph::add_function(const T& arguments) {
   return new_node_index;
 }
 
+struct RunNode;
+
 struct Run {
   Run(Hypergraph *hg, MemoryPool *fxs, MemoryPool *dEdfs) 
   : hg(hg), 
     fxs(fxs), 
     dEdfs(dEdfs),
-    last_node_evaluated()
-  { 
-    if (hg->running) {
-      std::cerr << "Only one run at a time can be active on a hypergraph.\n";
-      abort();
-    }
-    hg->running = true; 
-  };
-  ~Run() { hg->running = false; }
+    last_node_evaluated(),
+    runnodes()
+  { };
 
   Hypergraph *hg;
   MemoryPool *fxs, *dEdfs;
 
   VariableIndex last_node_evaluated; // enables forward graphs to be evaluated incrementally
 
+  std::vector<RunNode> runnodes; // parallel to Hypergraph::nodes
+
   // perform computations
   const Tensor& forward();
   const Tensor& incremental_forward();  // if you want to add nodes and evaluate just the new parts
   void backward();
 };
+
+// All the information about a node that pertains to a particular run
+struct RunNode {
+  // memory
+  Dim dim;  // will be .size() = 0 initially, before memory is allocated
+
+  // computation results (nb. memory is not owned by Tensor)
+  Tensor f;               // f(x_1 , ... , x_n)
+  Tensor dEdf;            // dE/df
+};
+
+inline void swap(RunNode& n1, RunNode& n2) {
+  using std::swap;
+  swap(n1.dim, n2.dim);
+  swap(n1.f, n2.f);
+  swap(n1.dEdf, n2.dEdf);
+}
 
 } // namespace cnn
 

--- a/examples/embed-cl.cc
+++ b/examples/embed-cl.cc
@@ -174,11 +174,12 @@ int main(int argc, char** argv) {
       }
       VariableIndex i_v = hg.add_function<Rectify>({hg.add_function<ConcatenateColumns>(noise)});
       hg.add_function<SumColumns>({i_v});
-      auto iloss = as_scalar(hg.forward());
+      Run run(&hg, fxs, dEdfs);
+      auto iloss = as_scalar(run.forward());
       assert(iloss >= 0);
       if (iloss > 0) {
         loss += iloss;
-        hg.backward();
+        run.backward();
         sgd->update();
       }
       ++lines;

--- a/examples/nlm.cc
+++ b/examples/nlm.cc
@@ -61,6 +61,8 @@ int main(int argc, char** argv) {
   hg.add_function<Negate>({i_nerr});
   hg.PrintGraphviz();
 
+  Run run(&hg, fxs, dEdfs);
+
   // load some training data
   if (argc != 2) {
     cerr << "Usage: " << argv[0] << " ngrams.txt\n";
@@ -90,8 +92,8 @@ int main(int argc, char** argv) {
       in_c2 = ci[1];
       in_c3 = ci[2];
       ytrue  = ci[3];
-      loss += as_scalar(hg.forward());
-      hg.backward();
+      loss += as_scalar(run.forward());
+      run.backward();
       ++n;
       sgd.update(1.0);
       if (n == 2500) break;

--- a/examples/xor-xent.cc
+++ b/examples/xor-xent.cc
@@ -61,6 +61,7 @@ int main(int argc, char** argv) {
   //  boost::archive::text_iarchive ia(in);
   //  ia >> m;
   //}
+  Run run(&hg, fxs, dEdfs);
 
   // train the parameters
   for (unsigned iter = 0; iter < 2000; ++iter) {
@@ -71,8 +72,8 @@ int main(int argc, char** argv) {
       x_values[0] = x1 ? 1 : 0;
       x_values[1] = x2 ? 1 : 0;
       y_value = (x1 != x2) ? 1 : 0;
-      loss += as_scalar(hg.forward());
-      hg.backward();
+      loss += as_scalar(run.forward());
+      run.backward();
       sgd.update(1.0);
     }
     sgd.update_epoch();

--- a/examples/xor.cc
+++ b/examples/xor.cc
@@ -66,6 +66,7 @@ int main(int argc, char** argv) {
     boost::archive::text_iarchive ia(in);
     ia >> m;
   }
+  Run run(&hg, fxs, dEdfs);
 
   // train the parameters
   for (unsigned iter = 0; iter < ITERATIONS; ++iter) {
@@ -76,8 +77,8 @@ int main(int argc, char** argv) {
       x_values[0] = x1 ? 1 : -1;
       x_values[1] = x2 ? 1 : -1;
       y_value = (x1 != x2) ? 1 : -1;
-      loss += as_scalar(hg.forward());
-      hg.backward();
+      loss += as_scalar(run.forward());
+      run.backward();
       sgd.update(1.0);
     }
     sgd.update_epoch();


### PR DESCRIPTION
Hypergraph is factored into Hypergraph and Run. Hypergraph is supposed to contain information about graph structure (nodes and edges) and Run is supposed to contain information about graph computations (all computed values, last evaluated node). The result is that there can now be more than one Hypergraph.

There is still some computation information in Hypergraph: inputs and gradients of parameters. So it won't quite work yet for there to be more than one Run for a single Hypergraph.