### PR TITLE
build instructions without Eigen

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ You need the [development version of the Eigen library](https://bitbucket.org/ei
 
     Assertion failed: (false && "heap allocation is forbidden (EIGEN_NO_MALLOC is defined)"), function check_that_malloc_is_allowed, file /Users/cdyer/software/eigen-eigen-10219c95fe65/Eigen/src/Core/util/Memory.h, line 188.
 
+
 #### Building
 
 In `src`, you need to first use [`cmake`](http://www.cmake.org/) to generate the makefiles
@@ -24,6 +25,20 @@ To see that things have built properly, you can run
     ./examples/xor
 
 which will train a multilayer perceptron to predict the xor function.
+
+#### Building without Eigen installed
+
+If you don't have Eigen installed, the instructions below will fetch and compile
+both `Eigen` and `cnn`.
+        
+    git clone https://github.com/yoavg/cnn.git
+    hg clone https://bitbucket.org/eigen/eigen/
+
+    cd cnn/
+    mkdir build
+    cd build
+    cmake .. -DEIGEN3_INCLUDE_DIR=../eigen
+    make -j 2
 
 #### Debugging
 


### PR DESCRIPTION
Just a small addition to the README to make it a tiny-bit easier to install.