### PR TITLE
Forward to node

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ You need the [development version of the Eigen library](https://bitbucket.org/ei
 
     Assertion failed: (false && "heap allocation is forbidden (EIGEN_NO_MALLOC is defined)"), function check_that_malloc_is_allowed, file /Users/cdyer/software/eigen-eigen-10219c95fe65/Eigen/src/Core/util/Memory.h, line 188.
 
+
 #### Building
 
 In `src`, you need to first use [`cmake`](http://www.cmake.org/) to generate the makefiles
@@ -24,6 +25,20 @@ To see that things have built properly, you can run
     ./examples/xor
 
 which will train a multilayer perceptron to predict the xor function.
+
+#### Building without Eigen installed
+
+If you don't have Eigen installed, the instructions below will fetch and compile
+both `Eigen` and `cnn`.
+        
+    git clone https://github.com/yoavg/cnn.git
+    hg clone https://bitbucket.org/eigen/eigen/
+
+    cd cnn/
+    mkdir build
+    cd build
+    cmake .. -DEIGEN3_INCLUDE_DIR=../eigen
+    make -j 2
 
 #### Debugging
 

--- a/cnn/CMakeLists.txt
+++ b/cnn/CMakeLists.txt
@@ -82,8 +82,8 @@ file(GLOB TEST_SRCS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} tests/*.cc)
 #endforeach(test_src)
 
 # actual target:
-#add_library(cnn ${cnn_library_SRCS} ${cnn_library_HDRS} ${LIBS})
-add_library(cnn SHARED ${cnn_library_SRCS} ${cnn_library_HDRS} ${LIBS})
+add_library(cnn ${cnn_library_SRCS} ${cnn_library_HDRS} ${LIBS})
+#add_library(cnn SHARED ${cnn_library_SRCS} ${cnn_library_HDRS} ${LIBS})
 if(WITH_CUDA_BACKEND)
   set(CUDA_SEPARABLE_COMPILATION ON)
   list(APPEND CUDA_NVCC_FLAGS "-gencode;arch=compute_20,code=sm_20;-gencode;arch=compute_30,code=sm_30;-gencode;arch=compute_35,code=sm_35;-gencode;arch=compute_37,code=sm_37;-gencode;arch=compute_50,code=sm_50;-gencode;arch=compute_52,code=sm_52;-gencode;arch=compute_52,code=compute_52;-std=c++11;-O2;-DVERBOSE")

--- a/cnn/CMakeLists.txt
+++ b/cnn/CMakeLists.txt
@@ -82,7 +82,8 @@ file(GLOB TEST_SRCS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} tests/*.cc)
 #endforeach(test_src)
 
 # actual target:
-add_library(cnn ${cnn_library_SRCS} ${cnn_library_HDRS} ${LIBS})
+#add_library(cnn ${cnn_library_SRCS} ${cnn_library_HDRS} ${LIBS})
+add_library(cnn SHARED ${cnn_library_SRCS} ${cnn_library_HDRS} ${LIBS})
 if(WITH_CUDA_BACKEND)
   set(CUDA_SEPARABLE_COMPILATION ON)
   list(APPEND CUDA_NVCC_FLAGS "-gencode;arch=compute_20,code=sm_20;-gencode;arch=compute_30,code=sm_30;-gencode;arch=compute_35,code=sm_35;-gencode;arch=compute_37,code=sm_37;-gencode;arch=compute_50,code=sm_50;-gencode;arch=compute_52,code=sm_52;-gencode;arch=compute_52,code=compute_52;-std=c++11;-O2;-DVERBOSE")

--- a/cnn/cnn.cc
+++ b/cnn/cnn.cc
@@ -113,6 +113,7 @@ void ComputationGraph::set_dim_for_new_node(const VariableIndex& i) {
 
 const Tensor& ComputationGraph::incremental_forward() { return ee->incremental_forward(); }
 const Tensor& ComputationGraph::forward() { return ee->forward(); }
+const Tensor& ComputationGraph::get_value(VariableIndex i) { return ee->get_value(i); }
 void ComputationGraph::backward() { ee->backward(); }
 
 void ComputationGraph::PrintGraphviz() const {

--- a/cnn/cnn.cc
+++ b/cnn/cnn.cc
@@ -114,6 +114,7 @@ void ComputationGraph::set_dim_for_new_node(const VariableIndex& i) {
 const Tensor& ComputationGraph::incremental_forward() { return ee->incremental_forward(); }
 const Tensor& ComputationGraph::forward() { return ee->forward(); }
 const Tensor& ComputationGraph::get_value(VariableIndex i) { return ee->get_value(i); }
+void ComputationGraph::invalidate() { ee->invalidate(); }
 void ComputationGraph::backward() { ee->backward(); }
 
 void ComputationGraph::PrintGraphviz() const {

--- a/cnn/cnn.h
+++ b/cnn/cnn.h
@@ -73,9 +73,19 @@ struct ComputationGraph {
   template <class Function, typename T> inline VariableIndex add_function(const T& arguments);
 
   // perform computations
+
+  // run complete forward pass from first node to last existing one, ignoring all precomputed values.
   const Tensor& forward();
-  const Tensor& incremental_forward();  // if you want to add nodes and evaluate just the new parts
+  // run forward pass from the last computed node to last existing.
+  // useful if you want to add nodes and evaluate just the new parts.
+  const Tensor& incremental_forward();
+  // get forward value for node at index i. used cached values if available,
+  // performs forward evaluation if note available (may compute more than strictly
+  // what is needed).
   const Tensor& get_value(VariableIndex i);
+  // clears forward caches (for get_value etc).
+  void invalidate();
+  // computes backward gradients from the front-most evaluated node.
   void backward();
 
   // debugging

--- a/cnn/cnn.h
+++ b/cnn/cnn.h
@@ -75,6 +75,7 @@ struct ComputationGraph {
   // perform computations
   const Tensor& forward();
   const Tensor& incremental_forward();  // if you want to add nodes and evaluate just the new parts
+  const Tensor& get_value(VariableIndex i);
   void backward();
 
   // debugging

--- a/cnn/exec.cc
+++ b/cnn/exec.cc
@@ -8,14 +8,17 @@ namespace cnn {
 
 ExecutionEngine::~ExecutionEngine() {}
 
+void SimpleExecutionEngine::invalidate() {
+    last_node_evaluated = 0;
+}
 const Tensor& SimpleExecutionEngine::forward() {
-  last_node_evaluated = 0;
+  invalidate();
   return incremental_forward();
 }
 
 const Tensor& SimpleExecutionEngine::get_value(VariableIndex i) {
     assert(i < cg.nodes.size());
-    if (i < last_node_evaluated) {
+    if (i >= last_node_evaluated) {
         incremental_forward();
     }
     return nfxs[i];

--- a/cnn/exec.cc
+++ b/cnn/exec.cc
@@ -13,6 +13,14 @@ const Tensor& SimpleExecutionEngine::forward() {
   return incremental_forward();
 }
 
+const Tensor& SimpleExecutionEngine::get_value(VariableIndex i) {
+    assert(i < cg.nodes.size());
+    if (i < last_node_evaluated) {
+        incremental_forward();
+    }
+    return nfxs[i];
+}
+
 const Tensor& SimpleExecutionEngine::incremental_forward() {
   // free any old memory if this is a new HG
   if (last_node_evaluated == 0) fxs->free();

--- a/cnn/exec.h
+++ b/cnn/exec.h
@@ -10,6 +10,7 @@ class ExecutionEngine {
   virtual ~ExecutionEngine();
   virtual const Tensor& forward() = 0;
   virtual const Tensor& incremental_forward() = 0;  // if you want to add nodes and evaluate just the new parts
+  virtual const Tensor& get_value(VariableIndex i) = 0;  
   virtual void backward() = 0;
  protected:
   explicit ExecutionEngine(const ComputationGraph& cg) : cg(cg) {}
@@ -21,6 +22,7 @@ class SimpleExecutionEngine : public ExecutionEngine {
   explicit SimpleExecutionEngine(const ComputationGraph& cg) : ExecutionEngine(cg) {}
   const Tensor& forward() override;
   const Tensor& incremental_forward() override;  // if you want to add nodes and evaluate just the new parts
+  const Tensor& get_value(VariableIndex i) override; 
   void backward() override;
  private:
   std::vector<Tensor> nfxs;

--- a/cnn/exec.h
+++ b/cnn/exec.h
@@ -8,6 +8,7 @@ namespace cnn {
 class ExecutionEngine {
  public:
   virtual ~ExecutionEngine();
+  virtual void invalidate() = 0;
   virtual const Tensor& forward() = 0;
   virtual const Tensor& incremental_forward() = 0;  // if you want to add nodes and evaluate just the new parts
   virtual const Tensor& get_value(VariableIndex i) = 0;  
@@ -20,6 +21,7 @@ class ExecutionEngine {
 class SimpleExecutionEngine : public ExecutionEngine {
  public:
   explicit SimpleExecutionEngine(const ComputationGraph& cg) : ExecutionEngine(cg) {}
+  void invalidate() override;
   const Tensor& forward() override;
   const Tensor& incremental_forward() override;  // if you want to add nodes and evaluate just the new parts
   const Tensor& get_value(VariableIndex i) override; 

--- a/cnn/expr.h
+++ b/cnn/expr.h
@@ -12,6 +12,7 @@ struct Expression {
 
   Expression() : pg(nullptr) { }
   Expression(ComputationGraph *pg, VariableIndex i) : pg(pg), i(i) { }
+  const Tensor& value() { return pg->get_value(i); }
 };
 
 Expression input(ComputationGraph& g, real s);

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,6 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
 
-foreach(TARGET tag-bilstm embed-cl encdec xor xor-xent rnnlm nlm textcat)
+foreach(TARGET tag-bilstm embed-cl encdec xor xor-xent rnnlm nlm textcat rnnlm2)
   ADD_EXECUTABLE(${TARGET} ${TARGET}.cc)
   target_link_libraries(${TARGET} cnn ${LIBS})
   if (WITH_CUDA_BACKEND)

--- a/examples/rnnlm2.cc
+++ b/examples/rnnlm2.cc
@@ -1,0 +1,253 @@
+#include "cnn/nodes.h"
+#include "cnn/cnn.h"
+#include "cnn/training.h"
+#include "cnn/timing.h"
+#include "cnn/rnn.h"
+#include "cnn/gru.h"
+#include "cnn/lstm.h"
+#include "cnn/dict.h"
+# include "cnn/expr.h"
+
+#include <iostream>
+#include <fstream>
+#include <sstream>
+
+#include <boost/archive/text_iarchive.hpp>
+#include <boost/archive/text_oarchive.hpp>
+
+using namespace std;
+using namespace cnn;
+
+unsigned LAYERS = 2;
+unsigned INPUT_DIM = 8;  //256
+unsigned HIDDEN_DIM = 24;  // 1024
+unsigned VOCAB_SIZE = 0;
+
+cnn::Dict d;
+int kSOS;
+int kEOS;
+
+template <class Builder>
+struct RNNLanguageModel {
+  LookupParameters* p_c;
+  Parameters* p_R;
+  Parameters* p_bias;
+  Builder builder;
+  explicit RNNLanguageModel(Model& model) : builder(LAYERS, INPUT_DIM, HIDDEN_DIM, &model) {
+    p_c = model.add_lookup_parameters(VOCAB_SIZE, {INPUT_DIM}); 
+    p_R = model.add_parameters({VOCAB_SIZE, HIDDEN_DIM});
+    p_bias = model.add_parameters({VOCAB_SIZE});
+  }
+
+  // return Expression of total loss
+  Expression BuildLMGraph(const vector<int>& sent, ComputationGraph& cg) {
+    const unsigned slen = sent.size() - 1;
+    builder.new_graph(cg);  // reset RNN builder for new graph
+    builder.start_new_sequence();
+    Expression i_R = parameter(cg, p_R); // hidden -> word rep parameter
+    Expression i_bias = parameter(cg, p_bias);  // word bias
+    vector<Expression> errs;
+    for (unsigned t = 0; t < slen; ++t) {
+      Expression i_x_t = lookup(cg, p_c, sent[t]);
+      // y_t = RNN(x_t)
+      Expression i_y_t = builder.add_input(i_x_t);
+      Expression i_r_t =  i_bias + i_R * i_y_t;
+      
+      // we can easily look at intermidiate values
+      std::vector<float> r_t = as_vector(i_r_t.value());
+      for (float f : r_t) cout << f << " "; cout << endl;
+      cout << "[" << as_scalar(pick(i_r_t, sent[t+1]).value()) << "]" << endl;
+
+      // LogSoftmax followed by PickElement can be written in one step
+      // using PickNegLogSoftmax
+#if 0
+      Expression i_ydist = logsoftmax(i_r_t);
+      errs.push_back(pick(i_ydist, sent[t+1]));
+#if 0
+      Expression i_ydist = softmax(i_r_t);
+      i_ydist = log(i_ydist)
+      errs.push_back(pick(i_ydist, sent[t+1]));
+#endif
+#else
+      Expression i_err = pickneglogsoftmax(i_r_t, sent[t+1]);
+      errs.push_back(i_err);
+#endif
+    }
+    Expression i_nerr = sum(errs);
+#if 0
+    return -i_nerr;
+#else
+    return i_nerr;
+#endif
+  }
+
+  // return Expression for total loss
+  void RandomSample(int max_len = 150) {
+    cerr << endl;
+    ComputationGraph cg;
+    builder.new_graph(cg);  // reset RNN builder for new graph
+    builder.start_new_sequence();
+    
+    Expression i_R = parameter(cg, p_R);
+    Expression i_bias = parameter(cg, p_bias);
+    vector<Expression> errs;
+    int len = 0;
+    int cur = kSOS;
+    while(len < max_len && cur != kEOS) {
+      ++len;
+      Expression i_x_t = lookup(cg, p_c, cur);
+      // y_t = RNN(x_t)
+      Expression i_y_t = builder.add_input(i_x_t);
+      Expression i_r_t = i_bias + i_R * i_y_t;
+      
+      Expression ydist = softmax(i_r_t);
+      
+      unsigned w = 0;
+      while (w == 0 || (int)w == kSOS) {
+        auto dist = as_vector(cg.incremental_forward());
+        double p = rand01();
+        for (; w < dist.size(); ++w) {
+          p -= dist[w];
+          if (p < 0.0) { break; }
+        }
+        if (w == dist.size()) w = kEOS;
+      }
+      cerr << (len == 1 ? "" : " ") << d.Convert(w);
+      cur = w;
+    }
+    cerr << endl;
+  }
+};
+
+int main(int argc, char** argv) {
+  cnn::Initialize(argc, argv);
+  if (argc != 3 && argc != 4) {
+    cerr << "Usage: " << argv[0] << " corpus.txt dev.txt [model.params]\n";
+    return 1;
+  }
+  kSOS = d.Convert("<s>");
+  kEOS = d.Convert("</s>");
+  vector<vector<int>> training, dev;
+  string line;
+  int tlc = 0;
+  int ttoks = 0;
+  cerr << "Reading training data from " << argv[1] << "...\n";
+  {
+    ifstream in(argv[1]);
+    assert(in);
+    while(getline(in, line)) {
+      ++tlc;
+      training.push_back(ReadSentence(line, &d));
+      ttoks += training.back().size();
+      if (training.back().front() != kSOS && training.back().back() != kEOS) {
+        cerr << "Training sentence in " << argv[1] << ":" << tlc << " didn't start or end with <s>, </s>\n";
+        abort();
+      }
+    }
+    cerr << tlc << " lines, " << ttoks << " tokens, " << d.size() << " types\n";
+  }
+  d.Freeze(); // no new word types allowed
+  VOCAB_SIZE = d.size();
+
+  int dlc = 0;
+  int dtoks = 0;
+  cerr << "Reading dev data from " << argv[2] << "...\n";
+  {
+    ifstream in(argv[2]);
+    assert(in);
+    while(getline(in, line)) {
+      ++dlc;
+      dev.push_back(ReadSentence(line, &d));
+      dtoks += dev.back().size();
+      if (dev.back().front() != kSOS && dev.back().back() != kEOS) {
+        cerr << "Dev sentence in " << argv[2] << ":" << tlc << " didn't start or end with <s>, </s>\n";
+        abort();
+      }
+    }
+    cerr << dlc << " lines, " << dtoks << " tokens\n";
+  }
+  ostringstream os;
+  os << "lm"
+     << '_' << LAYERS
+     << '_' << INPUT_DIM
+     << '_' << HIDDEN_DIM
+     << "-pid" << getpid() << ".params";
+  const string fname = os.str();
+  cerr << "Parameters will be written to: " << fname << endl;
+  double best = 9e+99;
+
+  Model model;
+  bool use_momentum = false;
+  Trainer* sgd = nullptr;
+  //if (use_momentum)
+  //  sgd = new MomentumSGDTrainer(&model);
+  //else
+  sgd = new SimpleSGDTrainer(&model);
+
+  RNNLanguageModel<LSTMBuilder> lm(model);
+  //RNNLanguageModel<SimpleRNNBuilder> lm(model);
+  if (argc == 4) {
+    string fname = argv[3];
+    ifstream in(fname);
+    boost::archive::text_iarchive ia(in);
+    ia >> model;
+  }
+
+  unsigned report_every_i = 50;
+  unsigned dev_every_i_reports = 500;
+  unsigned si = training.size();
+  vector<unsigned> order(training.size());
+  for (unsigned i = 0; i < order.size(); ++i) order[i] = i;
+  bool first = true;
+  int report = 0;
+  unsigned lines = 0;
+  while(1) {
+    Timer iteration("completed in");
+    double loss = 0;
+    unsigned chars = 0;
+    for (unsigned i = 0; i < report_every_i; ++i) {
+      if (si == training.size()) {
+        si = 0;
+        if (first) { first = false; } else { sgd->update_epoch(); }
+        cerr << "**SHUFFLE\n";
+        shuffle(order.begin(), order.end(), *rndeng);
+      }
+
+      // build graph for this instance
+      ComputationGraph cg;
+      auto& sent = training[order[si]];
+      chars += sent.size() - 1;
+      ++si;
+      lm.BuildLMGraph(sent, cg);
+      loss += as_scalar(cg.forward());
+      cg.backward();
+      sgd->update();
+      ++lines;
+    }
+    sgd->status();
+    cerr << " E = " << (loss / chars) << " ppl=" << exp(loss / chars) << ' ';
+    lm.RandomSample();
+
+    // show score on dev data?
+    report++;
+    if (report % dev_every_i_reports == 0) {
+      double dloss = 0;
+      int dchars = 0;
+      for (auto& sent : dev) {
+        ComputationGraph cg;
+        lm.BuildLMGraph(sent, cg);
+        dloss += as_scalar(cg.forward());
+        dchars += sent.size() - 1;
+      }
+      if (dloss < best) {
+        best = dloss;
+        ofstream out(fname);
+        boost::archive::text_oarchive oa(out);
+        oa << model;
+      }
+      cerr << "\n***DEV [epoch=" << (lines / (double)training.size()) << "] E = " << (dloss / dchars) << " ppl=" << exp(dloss / dchars) << ' ';
+    }
+  }
+  delete sgd;
+}
+


### PR DESCRIPTION
This enhances the ComputationGraph computation API to support easily querying the values of specific nodes. (see usage example in examples/rnnlm2.cc)