### PR TITLE
stochastically dropout an entire expression

### DIFF
--- a/cnn/expr.cc
+++ b/cnn/expr.cc
@@ -46,6 +46,7 @@ Expression min(const Expression& x, const Expression& y) { return Expression(x.p
 Expression max(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<Max>({x.i, y.i})); }
 Expression noise(const Expression& x, real stddev) { return Expression(x.pg, x.pg->add_function<GaussianNoise>({x.i}, stddev)); }
 Expression dropout(const Expression& x, real p) { return Expression(x.pg, x.pg->add_function<Dropout>({x.i}, p)); }
+Expression block_dropout(const Expression& x, real p) { return Expression(x.pg, x.pg->add_function<BlockDropout>({x.i}, p)); }
 
 Expression reshape(const Expression& x, const Dim& d) { return Expression(x.pg, x.pg->add_function<Reshape>({x.i}, d)); }
 Expression transpose(const Expression& x) { return Expression(x.pg, x.pg->add_function<Transpose>({x.i})); }

--- a/cnn/expr.h
+++ b/cnn/expr.h
@@ -59,6 +59,7 @@ Expression min(const Expression& x, const Expression& y);
 Expression max(const Expression& x, const Expression& y);
 Expression noise(const Expression& x, real stddev);
 Expression dropout(const Expression& x, real p);
+Expression block_dropout(const Expression& x, real p);
 
 Expression reshape(const Expression& x, const Dim& d);
 Expression transpose(const Expression& x);

--- a/cnn/nodes-common.cc
+++ b/cnn/nodes-common.cc
@@ -193,6 +193,17 @@ Dim Dropout::dim_forward(const vector<Dim>& xs) const {
   return xs[0];
 }
 
+string BlockDropout::as_string(const vector<string>& arg_names) const {
+  ostringstream s;
+  s << "block_dropout(" << arg_names[0] << ",dropout_probability=" << dropout_probability << ')';
+  return s.str();
+}
+
+Dim BlockDropout::dim_forward(const vector<Dim>& xs) const {
+  assert(xs.size() == 1);
+  return xs[0];
+}
+
 string ConstantPlusX::as_string(const vector<string>& arg_names) const {
   ostringstream s;
   s << c << " + " << arg_names[0];

--- a/cnn/nodes.h
+++ b/cnn/nodes.h
@@ -181,6 +181,21 @@ struct Dropout : public Node {
   real p;
 };
 
+// y = block_dropout(x,p) where p specifies the probability for dropping-out the entire block
+struct BlockDropout : public Node {
+  explicit BlockDropout(const std::initializer_list<VariableIndex>& a, real p) : Node(a), dropout_probability(p) {}
+  std::string as_string(const std::vector<std::string>& arg_names) const override;
+  Dim dim_forward(const std::vector<Dim>& xs) const override;
+  size_t aux_storage_size() const override;
+  void forward(const std::vector<const Tensor*>& xs, Tensor& fx) const override;
+  void backward(const std::vector<const Tensor*>& xs,
+                const Tensor& fx,
+                const Tensor& dEdf,
+                unsigned i,
+                Tensor& dEdxi) const override;
+  real dropout_probability;
+};
+
 // y = c + x_1
 // (c is a vector or matrix of the constant, usually 1, but can be configured)
 struct ConstantPlusX : public Node {


### PR DESCRIPTION
Unlike traditional dropout() which stochastically zeros individual scalars in an expression, block_dropout() stochastically zeros the entire expression.