### PR TITLE
Assert that in `incremental_forward(i)`, `i` is not out of bounds.  

### DIFF
--- a/cnn/cnn.cc
+++ b/cnn/cnn.cc
@@ -18,7 +18,7 @@ int n_hgs = 0;
 Node::~Node() {}
 size_t Node::aux_storage_size() const { return 0; }
 
-ComputationGraph::ComputationGraph() : last_node_evaluated(),
+ComputationGraph::ComputationGraph() :
   ee(new SimpleExecutionEngine(*this)) {
   ++n_hgs;
   if (n_hgs > 1) {
@@ -34,7 +34,6 @@ ComputationGraph::~ComputationGraph() {
 }
 
 void ComputationGraph::clear() {
-  last_node_evaluated = VariableIndex();
   parameter_nodes.clear();
   for (auto n : nodes) delete n;
   nodes.clear();

--- a/cnn/cnn.h
+++ b/cnn/cnn.h
@@ -99,7 +99,6 @@ struct ComputationGraph {
   // data
   std::vector<Node*> nodes;       // **stored in topological order**
   std::vector<VariableIndex> parameter_nodes; // nodes that contain parameters that can be updated (subset of nodes)
-  VariableIndex last_node_evaluated; // enables forward graphs to be evaluated incrementally
 
   ExecutionEngine* ee;  // handles the execution
  private:

--- a/cnn/exec.cc
+++ b/cnn/exec.cc
@@ -36,6 +36,8 @@ const Tensor& SimpleExecutionEngine::incremental_forward() {
 }
 
 const Tensor& SimpleExecutionEngine::incremental_forward(VariableIndex i) {
+  assert(i < cg.nodes.size());
+
   // free any old memory if this is a new HG
   if (num_nodes_evaluated == 0) fxs->free();
 


### PR DESCRIPTION
* Added assertion that in `incremental_forward(i)`, `i` is not out of bounds.
* Also removed some dead code: CompuationalGraph.last_node_evaluated.