### PR TITLE
Updating installation instructions for PyCNN

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,5 +1,6 @@
 # Installing the pyCNN module.
 
+
 First, get CNN:
 
 ```bash
@@ -66,10 +67,6 @@ cd build
 cmake .. -DEIGEN3_INCLUDE_DIR=$PATH_TO_EIGEN -DBOOST_ROOT=$HOME/.local/boost_1_58_0 -DBoost_NO_BOOST_CMAKE=ON
 make -j 2
 ```
-
-# hg clone https://bitbucket.org/eigen/eigen/ # Latest version (17.03.16) of Eigen fails to compile.
-wget u.cs.biu.ac.il/~yogo/eigen.tgz
-tar zxvf eigen.tgz # or "dtrx eigen.tgz" if you have dtrx installed.
 
 Now that CNN is compiled, we need to compile the pycnn module.
 This requires having cython installed.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,7 +10,7 @@ git submodule init # To be consistent with CNN's installation instructions.
 git submodule update # To be consistent with CNN's installation instructions.
 # hg clone https://bitbucket.org/eigen/eigen/ # Latest version (17.03.16) of Eigen fails to compile.
 wget u.cs.biu.ac.il/~yogo/eigen.tgz
-tar zxvf eigen.tgz # or "dtrx eigen.tgz" if you have dtrx installed.
+tar zxvf eigen.tgz # or "dtrx eigen.tgz" if you have dtrx installed, e.g. with "sudo apt-get install dtrx"
 ```
 
 To simplify the following steps, we can set a bash variable to hold where we have saved the main directories of `cnn` and `eigen`. In case you have gotten `ccn` and `eigen` differently from the instructions above and saved them in different location(s), these variables will be helpful:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -13,7 +13,7 @@ wget u.cs.biu.ac.il/~yogo/eigen.tgz
 tar zxvf eigen.tgz # or "dtrx eigen.tgz" if you have dtrx installed.
 ```
 
-To simplify the following steps, we can set a bash variable to hold where we have saved the main directories of `cnn` and `eigen` (In case you have gotten `ccn` and `eigen` differently from the instructions above and saved them in different location(s)):
+To simplify the following steps, we can set a bash variable to hold where we have saved the main directories of `cnn` and `eigen`. In case you have gotten `ccn` and `eigen` differently from the instructions above and saved them in different location(s), these variables will be helpful:
 
 ```bash
 PARENT_DIR_OF_CNN=$HOME 
@@ -57,7 +57,7 @@ Add the following line to your profile (`.zshrc` or `.bashrc`), change
 according to your installation location.
 
 ```bash
-export LD_LIBRARY_PATH=$HOME/cnn/pycnn
+export LD_LIBRARY_PATH=$PARENT_DIR_OF_CNN/cnn/pycnn
 ```
 
 Now, check that everything works:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,6 +6,8 @@ First, get CNN and Eigen:
 cd $HOME
 git clone https://github.com/clab/cnn.git
 cd cnn
+git submodule init
+git submodule update
 # hg clone https://bitbucket.org/eigen/eigen/ # Latest version (17.03.16) of Eigen fails to compile.
 wget u.cs.biu.ac.il/~yogo/eigen.tgz
 tar zxvf eigen.tgz # or "dtrx eigen.tgz" if you have dtrx installed.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -25,7 +25,10 @@ If you don't have cython, it can be installed with either `pip install cython` o
 
 ```bash
 pip2 install cython --user
-cd $HOME/cnn/pycnn
+cd $HOME/cnn
+mkdir build/cnn
+cp cnn/libcnn_shared.so build/cnn/
+cd pycnn
 make
 make install
 ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -13,7 +13,7 @@ git submodule update # To be consistent with CNN's installation instructions.
 
 Then get Eigen:
 
-```
+```bash
 cd $HOME
 cd cnn
 # Latest version (17.03.16) of Eigen fails to compile , so we revert "-r" to the latest stable version.
@@ -41,7 +41,7 @@ make -j 2
 
 If CNN fails to compile and throws an error like this:
 
-```
+```bash
 $ make -j 2
 Scanning dependencies of target cnn
 Scanning dependencies of target cnn_shared
@@ -58,7 +58,7 @@ compilation terminated.
 
 If CNN fails to compile with the error above, then you can download a stable version of Eigen and re-build CNN as such:
 
-```
+```bash
 cd PARENT_DIR_OF_CNN/cnn
 wget u.cs.biu.ac.il/~yogo/eigen.tgz
 tar zxvf eigen.tgz # or "dtrx eigen.tgz" if you have dtrx installed

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,8 +6,8 @@ First, get CNN and Eigen:
 cd $HOME
 git clone https://github.com/clab/cnn.git
 cd cnn
-git submodule init
-git submodule update
+git submodule init # To be consistent with CNN's installation instructions.
+git submodule update # To be consistent with CNN's installation instructions.
 # hg clone https://bitbucket.org/eigen/eigen/ # Latest version (17.03.16) of Eigen fails to compile.
 wget u.cs.biu.ac.il/~yogo/eigen.tgz
 tar zxvf eigen.tgz # or "dtrx eigen.tgz" if you have dtrx installed.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -3,9 +3,9 @@
 First, get CNN and Eigen:
 
 ```bash
-mkdir cnn
-cd cnn
+cd $HOME
 git clone https://github.com/clab/cnn.git
+cd cnn
 # hg clone https://bitbucket.org/eigen/eigen/ # Latest version (17.03.16) of Eigen fails to compile.
 wget u.cs.biu.ac.il/~yogo/eigen.tgz
 tar zxvf eigen.tgz # or "dtrx eigen.tgz" if you have dtrx installed.
@@ -15,10 +15,7 @@ Compile CNN.
 (modify the code below to point to the correct boost location)
 
 ```bash
-cd cnn
-mkdir build
-cd build
-cmake .. -DEIGEN3_INCLUDE_DIR=../eigen -DBOOST_ROOT=/home/yogo/.local/boost_1_58_0 -DBoost_NO_BOOST_CMAKE=ON
+cmake -DEIGEN3_INCLUDE_DIR=./eigen -DBOOST_ROOT=$HOME/.local/boost_1_58_0 -DBoost_NO_BOOST_CMAKE=ON
 make -j 2
 ```
 
@@ -28,7 +25,7 @@ If you don't have cython, it can be installed with either `pip install cython` o
 
 ```bash
 pip2 install cython --user
-cd ../pycnn
+cd $HOME/cnn/pycnn
 make
 make install
 ```
@@ -41,7 +38,7 @@ Add the following line to your profile (`.zshrc` or `.bashrc`), change
 according to your installation location.
 
 ```bash
-export LD_LIBRARY_PATH=/home/yogo/cnn/cnn/pycnn
+export LD_LIBRARY_PATH=$HOME/cnn/pycnn
 ```
 
 Now, check that everything works:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -50,7 +50,7 @@ Now, check that everything works:
 
 ```bash
 # check that it works:
-cd ..
+cd $HOME/cnn
 cd pyexamples
 python2 xor.py
 python2 rnnlm.py rnnlm.py

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -13,14 +13,21 @@ wget u.cs.biu.ac.il/~yogo/eigen.tgz
 tar zxvf eigen.tgz # or "dtrx eigen.tgz" if you have dtrx installed.
 ```
 
+To simplify the following steps, we can set a bash variable to hold where we have saved the main directories of `cnn` and `eigen` (In case you have gotten `ccn` and `eigen` differently from the instructions above and saved them in different location(s)):
+
+```bash
+PARENT_DIR_OF_CNN=$HOME 
+PATH_TO_EIGEN=$HOME/cnn/eigen
+```
+
 Compile CNN.
 (modify the code below to point to the correct boost location)
 
 ```bash
-cd $HOME/cnn/
+cd PARENT_DIR_OF_CNN/cnn
 mkdir build
 cd build
-cmake .. -DEIGEN3_INCLUDE_DIR=../eigen -DBOOST_ROOT=$HOME/.local/boost_1_58_0 -DBoost_NO_BOOST_CMAKE=ON
+cmake .. -DEIGEN3_INCLUDE_DIR=$PATH_TO_EIGEN -DBOOST_ROOT=$HOME/.local/boost_1_58_0 -DBoost_NO_BOOST_CMAKE=ON
 make -j 2
 ```
 
@@ -30,7 +37,14 @@ If you don't have cython, it can be installed with either `pip install cython` o
 
 ```bash
 pip2 install cython --user
+```
+
+Customize the `setup.py` to include (i) the parent directory where the main `cnn` directory is saved and (ii) the path to the main `eigen` directy:
+
+```bash
 cd $HOME/cnn/pycnn
+sed -i  "s|..\/..\/cnn\/|$PARENT_DIR_OF_CNN|g" setup.py 
+sed -i  "s|..\/..\/eigen\/|$PATH_TO_EIGEN|g" setup.py
 make
 make install
 ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,7 +6,9 @@ First, get CNN and Eigen:
 mkdir cnn
 cd cnn
 git clone https://github.com/clab/cnn.git
-hg clone https://bitbucket.org/eigen/eigen/
+# hg clone https://bitbucket.org/eigen/eigen/ # Latest version (17.03.16) of Eigen fails to compile.
+wget u.cs.biu.ac.il/~yogo/eigen.tgz
+tar zxvf eigen.tgz # or "dtrx eigen.tgz" if you have dtrx installed.
 ```
 
 Compile CNN.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,15 +24,15 @@ hg clone https://bitbucket.org/eigen/eigen/ -r 47fa289dda2dc13e0eea70adfc8671e93
 To simplify the following steps, we can set a bash variable to hold where we have saved the main directories of `cnn` and `eigen`. In case you have gotten `ccn` and `eigen` differently from the instructions above and saved them in different location(s), these variables will be helpful:
 
 ```bash
-PARENT_DIR_OF_CNN=$HOME 
-PATH_TO_EIGEN=$HOME/cnn/eigen
+PATH_TO_CNN=$HOME/cnn/
+PATH_TO_EIGEN=$HOME/cnn/eigen/
 ```
 
 Compile CNN.
 (modify the code below to point to the correct boost location)
 
 ```bash
-cd PARENT_DIR_OF_CNN/cnn
+cd $PATH_TO_CNN
 mkdir build
 cd build
 cmake .. -DEIGEN3_INCLUDE_DIR=$PATH_TO_EIGEN -DBOOST_ROOT=$HOME/.local/boost_1_58_0 -DBoost_NO_BOOST_CMAKE=ON
@@ -59,7 +59,7 @@ compilation terminated.
 If CNN fails to compile with the error above, then you can download a stable version of Eigen and re-build CNN as such:
 
 ```bash
-cd PARENT_DIR_OF_CNN/cnn
+cd $PATH_TO_CNN
 wget u.cs.biu.ac.il/~yogo/eigen.tgz
 tar zxvf eigen.tgz # or "dtrx eigen.tgz" if you have dtrx installed
 mkdir build
@@ -79,8 +79,8 @@ pip2 install cython --user
 Customize the `setup.py` to include (i) the parent directory where the main `cnn` directory is saved and (ii) the path to the main `eigen` directy:
 
 ```bash
-cd $PARENT_DIR_OF_CNN/cnn/pycnn
-sed -i  "s|..\/..\/cnn\/|$PARENT_DIR_OF_CNN|g" setup.py 
+cd $PATH_TO_CNN/pycnn
+sed -i  "s|..\/..\/cnn\/|$PATH_TO_CNN|g" setup.py 
 sed -i  "s|..\/..\/eigen\/|$PATH_TO_EIGEN|g" setup.py
 make
 make install
@@ -94,14 +94,14 @@ Add the following line to your profile (`.zshrc` or `.bashrc`), change
 according to your installation location.
 
 ```bash
-export LD_LIBRARY_PATH=$PARENT_DIR_OF_CNN/cnn/pycnn
+export LD_LIBRARY_PATH=$PATH_TO_CNN/pycnn
 ```
 
 Now, check that everything works:
 
 ```bash
 # check that it works:
-cd $HOME/cnn
+cd $PATH_TO_CNN
 cd pyexamples
 python2 xor.py
 python2 rnnlm.py rnnlm.py

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,7 +10,7 @@ git submodule init # To be consistent with CNN's installation instructions.
 git submodule update # To be consistent with CNN's installation instructions.
 # hg clone https://bitbucket.org/eigen/eigen/ # Latest version (17.03.16) of Eigen fails to compile.
 wget u.cs.biu.ac.il/~yogo/eigen.tgz
-tar zxvf eigen.tgz # or "dtrx eigen.tgz" if you have dtrx installed, e.g. with "sudo apt-get install dtrx"
+tar zxvf eigen.tgz # or "dtrx eigen.tgz" if you have dtrx installed.
 ```
 
 To simplify the following steps, we can set a bash variable to hold where we have saved the main directories of `cnn` and `eigen`. In case you have gotten `ccn` and `eigen` differently from the instructions above and saved them in different location(s), these variables will be helpful:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -42,7 +42,7 @@ pip2 install cython --user
 Customize the `setup.py` to include (i) the parent directory where the main `cnn` directory is saved and (ii) the path to the main `eigen` directy:
 
 ```bash
-cd $HOME/cnn/pycnn
+cd $PARENT_DIR_OF_CNN/cnn/pycnn
 sed -i  "s|..\/..\/cnn\/|$PARENT_DIR_OF_CNN|g" setup.py 
 sed -i  "s|..\/..\/eigen\/|$PATH_TO_EIGEN|g" setup.py
 make

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,6 +15,9 @@ Compile CNN.
 (modify the code below to point to the correct boost location)
 
 ```bash
+cd $HOME/cnn/
+mkdir build
+cd build
 cmake -DEIGEN3_INCLUDE_DIR=./eigen -DBOOST_ROOT=$HOME/.local/boost_1_58_0 -DBoost_NO_BOOST_CMAKE=ON
 make -j 2
 ```
@@ -25,10 +28,7 @@ If you don't have cython, it can be installed with either `pip install cython` o
 
 ```bash
 pip2 install cython --user
-cd $HOME/cnn
-mkdir build/cnn
-cp cnn/libcnn_shared.so build/cnn/
-cd pycnn
+cd $HOME/cnn/pycnn
 make
 make install
 ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 # Installing the pyCNN module.
 
-First, get CNN and Eigen:
+First, get CNN:
 
 ```bash
 cd $HOME
@@ -8,9 +8,16 @@ git clone https://github.com/clab/cnn.git
 cd cnn
 git submodule init # To be consistent with CNN's installation instructions.
 git submodule update # To be consistent with CNN's installation instructions.
-# hg clone https://bitbucket.org/eigen/eigen/ # Latest version (17.03.16) of Eigen fails to compile.
-wget u.cs.biu.ac.il/~yogo/eigen.tgz
-tar zxvf eigen.tgz # or "dtrx eigen.tgz" if you have dtrx installed.
+```
+
+Then get Eigen:
+
+```
+cd $HOME
+cd cnn
+# Latest version (17.03.16) of Eigen fails to compile , so we revert "-r" to the latest stable version.
+# Otherwise, we can use "hg clone https://bitbucket.org/eigen/eigen/"
+hg clone https://bitbucket.org/eigen/eigen/ -r 47fa289dda2dc13e0eea70adfc8671e93627d466
 ```
 
 To simplify the following steps, we can set a bash variable to hold where we have saved the main directories of `cnn` and `eigen`. In case you have gotten `ccn` and `eigen` differently from the instructions above and saved them in different location(s), these variables will be helpful:
@@ -30,6 +37,39 @@ cd build
 cmake .. -DEIGEN3_INCLUDE_DIR=$PATH_TO_EIGEN -DBOOST_ROOT=$HOME/.local/boost_1_58_0 -DBoost_NO_BOOST_CMAKE=ON
 make -j 2
 ```
+
+If CNN fails to compile and throws an error like this:
+
+```
+$ make -j 2
+Scanning dependencies of target cnn
+Scanning dependencies of target cnn_shared
+[  1%] [  2%] Building CXX object cnn/CMakeFiles/cnn.dir/cfsm-builder.cc.o
+Building CXX object cnn/CMakeFiles/cnn_shared.dir/cfsm-builder.cc.o
+In file included from /home/user/cnn/cnn/cnn.h:13:0,
+                 from /home/user/cnn/cnn/cfsm-builder.h:6,
+                 from /home/user/cnn/cnn/cfsm-builder.cc:1:
+/home/user/cnn/cnn/tensor.h:22:42: fatal error: unsupported/Eigen/CXX11/Tensor: No such file or directory
+ #include <unsupported/Eigen/CXX11/Tensor>
+                                          ^
+compilation terminated.
+```
+
+Then, you can download a stable version of Eigen and re-build CNN as such:
+
+```
+cd PARENT_DIR_OF_CNN/cnn
+wget u.cs.biu.ac.il/~yogo/eigen.tgz
+tar zxvf eigen.tgz # or "dtrx eigen.tgz" if you have dtrx installed
+mkdir build
+cd build
+cmake .. -DEIGEN3_INCLUDE_DIR=$PATH_TO_EIGEN -DBOOST_ROOT=$HOME/.local/boost_1_58_0 -DBoost_NO_BOOST_CMAKE=ON
+make -j 2
+```
+
+# hg clone https://bitbucket.org/eigen/eigen/ # Latest version (17.03.16) of Eigen fails to compile.
+wget u.cs.biu.ac.il/~yogo/eigen.tgz
+tar zxvf eigen.tgz # or "dtrx eigen.tgz" if you have dtrx installed.
 
 Now that CNN is compiled, we need to compile the pycnn module.
 This requires having cython installed.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -20,7 +20,7 @@ Compile CNN.
 cd $HOME/cnn/
 mkdir build
 cd build
-cmake -DEIGEN3_INCLUDE_DIR=./eigen -DBOOST_ROOT=$HOME/.local/boost_1_58_0 -DBoost_NO_BOOST_CMAKE=ON
+cmake .. -DEIGEN3_INCLUDE_DIR=../eigen -DBOOST_ROOT=$HOME/.local/boost_1_58_0 -DBoost_NO_BOOST_CMAKE=ON
 make -j 2
 ```
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -55,7 +55,7 @@ In file included from /home/user/cnn/cnn/cnn.h:13:0,
 compilation terminated.
 ```
 
-Then, you can download a stable version of Eigen and re-build CNN as such:
+If CNN fails to compile with the error above, then you can download a stable version of Eigen and re-build CNN as such:
 
 ```
 cd PARENT_DIR_OF_CNN/cnn

--- a/pycnn/setup.py
+++ b/pycnn/setup.py
@@ -13,7 +13,7 @@ ext = Extension(
         "pycnn",                 # name of extension
         ["pycnn.pyx"],           # filename of our Pyrex/Cython source
         language="c++",              # this causes Pyrex/Cython to create C++ source
-        include_dirs=["../../cnn/", # this should be the parent directory of cnn
+        include_dirs=["../../cnn/", # this is the location of the main cnn directory.
                       "../../eigen/"], # this is the directory where eigen is saved.
         libraries=['cnn_shared'],             # ditto
         library_dirs=["."],

--- a/pycnn/setup.py
+++ b/pycnn/setup.py
@@ -13,8 +13,8 @@ ext = Extension(
         "pycnn",                 # name of extension
         ["pycnn.pyx"],           # filename of our Pyrex/Cython source
         language="c++",              # this causes Pyrex/Cython to create C++ source
-        include_dirs=["../../cnn/",
-                      "../../eigen/"],
+        include_dirs=["../../cnn/", # this should be the parent directory of cnn
+                      "../eigen/"], # this is the directory where eigen is saved.
         libraries=['cnn_shared'],             # ditto
         library_dirs=["."],
         #extra_link_args=["-L/home/yogo/Vork/Research/cnn/cnn/build/cnn"],       # if needed

--- a/pycnn/setup.py
+++ b/pycnn/setup.py
@@ -14,7 +14,7 @@ ext = Extension(
         ["pycnn.pyx"],           # filename of our Pyrex/Cython source
         language="c++",              # this causes Pyrex/Cython to create C++ source
         include_dirs=["../../cnn/", # this should be the parent directory of cnn
-                      "../eigen/"], # this is the directory where eigen is saved.
+                      "../../eigen/"], # this is the directory where eigen is saved.
         libraries=['cnn_shared'],             # ditto
         library_dirs=["."],
         #extra_link_args=["-L/home/yogo/Vork/Research/cnn/cnn/build/cnn"],       # if needed


### PR DESCRIPTION
I have added more generic installation instructions, I've remove the multiple nested directories to get to the src, previously it was `mkdir cnn; git clone ...cnn.git` and it creates nested `cnn/cnn/cnn` path to get to the src directory, now it's `cnn/cnn`. 

Possibly, the source directory should be renamed to `cnn/src` in the future but it would require proper refactoring which this PR doesn't cover.

Hope this will help improve the installation process of `PyCNN` and more people can start using this nice tool!
