### PR TITLE
Add missing header files, so 'include' directory has all needed files.

### DIFF
--- a/cnn/CMakeLists.txt
+++ b/cnn/CMakeLists.txt
@@ -39,6 +39,7 @@ set(cnn_library_HDRS
     cnn.h
     conv.h
     cuda.h
+    devices.h
     dict.h
     dim.h
     exec.h
@@ -52,6 +53,7 @@ set(cnn_library_HDRS
     hsm-builder.h
     init.h
     lstm.h
+    mem.h
     model.h
     mp.h
     nodes.h


### PR DESCRIPTION
Might be missing something, but if you `make install` this locally to use in another project, the install headers are missing these two files which prevent you from including `<cnn/cnn.h>`