### PR TITLE
Added error messages when empty lists are passed to PyCNN functions.

### DIFF
--- a/pycnn/pycnn.pyx
+++ b/pycnn/pycnn.pyx
@@ -675,6 +675,7 @@ cpdef Expression block_dropout(Expression x, float p): return Expression.from_ce
 cpdef Expression reshape(Expression x, tuple d): return Expression.from_cexpr(x.cg_version, c_reshape(x.c(),Dim(d)))
 
 cpdef Expression esum(list xs):
+    assert xs, 'List is empty, nothing to esum.'
     cdef vector[CExpression] cvec
     cvec = vector[CExpression]()
     cdef Expression x
@@ -685,6 +686,7 @@ cpdef Expression esum(list xs):
     return Expression.from_cexpr(x.cg_version, c_sum(cvec))
 
 cpdef Expression average(list xs):
+    assert xs, 'List is empty, nothing to average.'
     cdef vector[CExpression] cvec
     cdef Expression x
     for x in xs: 
@@ -693,6 +695,7 @@ cpdef Expression average(list xs):
     return Expression.from_cexpr(x.cg_version, c_average(cvec))
 
 cpdef Expression emax(list xs):
+    assert xs, 'List is empty, nothing to emax.'
     cdef Expression c
     cdef Expression x
     c = xs[0]
@@ -704,6 +707,7 @@ cpdef Expression emax(list xs):
     #return Expression.from_cexpr(x.cg_version, c_max(cvec))
 
 cpdef Expression concatenate_cols(list xs):
+    assert xs, 'List is empty, nothing to concatenate.'
     cdef vector[CExpression] cvec
     cdef Expression x
     for x in xs:
@@ -712,6 +716,7 @@ cpdef Expression concatenate_cols(list xs):
     return Expression.from_cexpr(x.cg_version, c_concat_cols(cvec))
 
 cpdef Expression concatenate(list xs):
+    assert xs, 'List is empty, nothing to concatenate.'
     cdef vector[CExpression] cvec
     cdef Expression x
     for x in xs:
@@ -721,6 +726,7 @@ cpdef Expression concatenate(list xs):
 
 
 cpdef Expression affine_transform(list exprs):
+    assert xs, 'List input to affine_transform must not be empty.'
     cdef Expression e
     cdef vector[CExpression] ves
     for e in exprs:

--- a/pycnn/pycnn.pyx
+++ b/pycnn/pycnn.pyx
@@ -726,7 +726,7 @@ cpdef Expression concatenate(list xs):
 
 
 cpdef Expression affine_transform(list exprs):
-    assert xs, 'List input to affine_transform must not be empty.'
+    assert exprs, 'List input to affine_transform must not be empty.'
     cdef Expression e
     cdef vector[CExpression] ves
     for e in exprs:


### PR DESCRIPTION
Errors were previously more cryptic.

@yoavg 