### PR TITLE
Support for memory larger than 2000MB

### DIFF
--- a/cnn/devices.cc
+++ b/cnn/devices.cc
@@ -11,7 +11,7 @@ namespace cnn {
 Device::~Device() {}
 
 #if HAVE_CUDA
-Device_GPU::Device_GPU(int mb, int device_id) :
+Device_GPU::Device_GPU(size_t mb, int device_id) :
     Device(DeviceType::GPU, &gpu_mem), cuda_device_id(device_id), gpu_mem(device_id) {
   CUDA_CHECK(cudaSetDevice(device_id));
   CUBLAS_CHECK(cublasCreate(&cublas_handle));
@@ -40,7 +40,7 @@ Device_GPU::~Device_GPU() {}
 // CPU -- 0 params
 //     -- 50mb fxs
 //     -- 50mb dEdfx
-Device_CPU::Device_CPU(int mb, bool shared) :
+Device_CPU::Device_CPU(size_t mb, bool shared) :
     Device(DeviceType::CPU, &cpu_mem), shmem(mem) {
   if (shared) shmem = new SharedAllocator();
   kSCALAR_MINUSONE = (float*) mem->malloc(sizeof(float));

--- a/cnn/devices.h
+++ b/cnn/devices.h
@@ -30,7 +30,7 @@ class Device {
 #if HAVE_CUDA
 class Device_GPU : public Device {
  public:
-  explicit Device_GPU(int mb, int device_id);
+  explicit Device_GPU(size_t mb, int device_id);
   ~Device_GPU();
   int cuda_device_id;
   cublasHandle_t cublas_handle;
@@ -40,7 +40,7 @@ class Device_GPU : public Device {
 
 class Device_CPU : public Device {
  public:
-  explicit Device_CPU(int mb, bool shared);
+  explicit Device_CPU(size_t mb, bool shared);
   ~Device_CPU();
   CPUAllocator cpu_mem;
   MemAllocator* shmem;


### PR DESCRIPTION
If we need memory larger than 2000MB (mb=2000), the code "mb << 20" in devices.cc will get a wrong number and lead to a failed allocation, due to the limited range of "int" type. When we change the type of mb from "int" to "size_t", the problem is solved.